### PR TITLE
Update planck-js to use new repository and npm for auto-update

### DIFF
--- a/packages/p/planck-js.json
+++ b/packages/p/planck-js.json
@@ -16,11 +16,11 @@
   "license": "Zlib",
   "repository": {
     "type": "git",
-    "url": "git://github.com/shakiba/planck.js.git"
+    "url": "git://github.com/piqnt/planck.js.git"
   },
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/shakiba/planck.js.git",
+    "source": "npm",
+    "target": "planck",
     "fileMap": [
       {
         "basePath": "dist",


### PR DESCRIPTION
Update planck-js configuration for cdnjs:

1. Updated repository URL from shakiba/planck.js to piqnt/planck.js
   - The original repository has been transferred, as evidenced by GitHub's redirect

2. Changed auto-update source from git to npm
   - The npm package "planck" is now the primary distribution method

3. Updated auto-update target to "planck" to match the current npm package name

These changes will allow cdnjs to fetch the latest versions of planck-js from the correct source, ensuring users have access to the most up-to-date files.